### PR TITLE
fix use after free for compiler flags

### DIFF
--- a/compy/representations/extractors/common/clang_driver.cc
+++ b/compy/representations/extractors/common/clang_driver.cc
@@ -111,7 +111,7 @@ void ClangDriver::Invoke(std::string src, std::vector<::clang::FrontendAction *>
     args.push_back(optimizationLevelChr);
 
     // Additional flags.
-    for (auto flag : compilerFlags_) {
+    for (auto&& flag : compilerFlags_) {
         args.push_back(flag.c_str());
     }
 


### PR DESCRIPTION
auto flag means flag is copied to a local variable (std::string),
which is deallocated after each loop iteration.

So the pointer `flag.c_str()` was no longer valid after the loop iteration.