### PR TITLE
Better support for different LLVM/Clang build configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 project(gnns4code_native)
 
 set(CMAKE_CXX_STANDARD 14)
-set(Clang_DIR /usr/lib/llvm-10/lib/cmake/clang)
 
 find_package(LLVM 10)
-find_package(Clang)
-
-set_target_properties(LLVM PROPERTIES
-    IMPORTED_LINK_INTERFACE_LANGUAGES_RELWITHDEBINFO "C;CXX"
-    IMPORTED_LOCATION_RELWITHDEBINFO "-lpthread"
-)
+find_package(Clang PATHS /usr/lib/llvm-10/lib/cmake/clang)
 
 include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(gnns4code_native)
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(LLVM 10)
-find_package(Clang PATHS /usr/lib/llvm-10/lib/cmake/clang)
+
+# prefer Clang matching LLVM
+find_package(Clang HINTS "${LLVM_CMAKE_DIR}/../clang")
 
 include(FetchContent)
 

--- a/compy/representations/extractors/CMakeLists.txt
+++ b/compy/representations/extractors/CMakeLists.txt
@@ -34,6 +34,12 @@ target_include_directories(extractors_common PUBLIC
         ${LLVM_INCLUDE_DIRS}
         ${CLANG_INCLUDE_DIRS}
         )
+
+# if tools are linked against llvm shared object, we need to do the same
+# otherwise, we end up with two versions (shared and static) of llvm libs
+if(LLVM_LINK_LLVM_DYLIB)
+        set(REQ_LLVM_LIBRARIES LLVM)
+endif()
 target_link_libraries(extractors_common
         -Wl,--start-group
         ${REQ_LLVM_LIBRARIES}

--- a/compy/representations/extractors/CMakeLists.txt
+++ b/compy/representations/extractors/CMakeLists.txt
@@ -40,11 +40,18 @@ target_include_directories(extractors_common PUBLIC
 if(LLVM_LINK_LLVM_DYLIB)
         set(REQ_LLVM_LIBRARIES LLVM)
 endif()
+
+# if clang is built as a shared lib, use that, otherwise link to the static components
+if(DEFINED CLANG_LINK_CLANG_DYLIB AND CLANG_LINK_CLANG_DYLIB)
+	set(REQ_CLANG_LIBRARIES clang-cpp)
+else()
+        set(REQ_CLANG_LIBRARIES clangBasic clangFrontendTool)
+endif()
+
 target_link_libraries(extractors_common
         -Wl,--start-group
         ${REQ_LLVM_LIBRARIES}
-        clangBasic
-        clangFrontendTool
+        ${REQ_CLANG_LIBRARIES}
         -Wl,--end-group
         )
 target_compile_options(extractors_common PRIVATE


### PR DESCRIPTION
I had some problems building compy-learn because my LLVM/Clang build configuration was slightly different. On ArchLinux, clang doesn't ship with the static libs, while on NixOS, LLVM is built in Release mode which led to an issue with LLVM being linked in twice. This resulted in an error `LLVM: option <...> registered more than once!` when trying to load the extractors in python. 