### PR TITLE
Fix install script for pip >=20.3 + small fixes

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -19,13 +19,18 @@ function install_system_packages {
 function install_python_packages {
   CUDA=$1
 
-  pip install torch==1.5.0+${CUDA} -f https://download.pytorch.org/whl/torch_stable.html
-  pip install torch-scatter==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  pip install torch-sparse==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  pip install torch-cluster==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  pip install torch-spline-conv==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  pip install dgl
-  pip install tensorflow==2.2.0
+  python3 -m pip install torch==1.5.0+${CUDA} -f https://download.pytorch.org/whl/torch_stable.html
+  python3 -m pip install torchvision==0.6.0
+  python3 -m pip install torch-scatter==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+  python3 -m pip install torch-sparse==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+  python3 -m pip install torch-cluster==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+  python3 -m pip install torch-spline-conv==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+  if [[ "$CUDA" != "cpu" ]]; then
+    python3 -m pip install dgl-$CUDA
+  else
+    python3 -m pip install dgl
+  fi
+  python3 -m pip install tensorflow==2.2.0
 }
 
 
@@ -37,7 +42,9 @@ fi
 
 if [[ $(lsb_release -rs) == "16.04" ]] || [[ $(lsb_release -rs) == "18.04" ]]; then
   echo "OS supported."
-  add_llvm_10_apt_source $(lsb_release -rs)
+  if ! grep -q 'llvm-toolchain-.*-10' /etc/apt/sources.list; then
+    add_llvm_10_apt_source $(lsb_release -rs)
+  fi
 elif [[ $(lsb_release -rs) == "20.04" ]]; then
   echo "OS supported."
 else

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -21,10 +21,10 @@ function install_python_packages {
 
   python3 -m pip install torch==1.5.0+${CUDA} -f https://download.pytorch.org/whl/torch_stable.html
   python3 -m pip install torchvision==0.6.0
-  python3 -m pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
-  python3 -m pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
-  python3 -m pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
-  python3 -m pip install torch-spline-conv -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-scatter==2.0.5 -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-sparse==0.6.7 -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-cluster==1.5.7 -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-spline-conv==1.2.0 -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
   if [[ "$CUDA" != "cpu" ]]; then
     python3 -m pip install dgl-$CUDA
   else

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -21,10 +21,10 @@ function install_python_packages {
 
   python3 -m pip install torch==1.5.0+${CUDA} -f https://download.pytorch.org/whl/torch_stable.html
   python3 -m pip install torchvision==0.6.0
-  python3 -m pip install torch-scatter==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  python3 -m pip install torch-sparse==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  python3 -m pip install torch-cluster==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
-  python3 -m pip install torch-spline-conv==latest+${CUDA} -f https://pytorch-geometric.com/whl/torch-1.5.0.html
+  python3 -m pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
+  python3 -m pip install torch-spline-conv -f https://pytorch-geometric.com/whl/torch-1.5.0+${CUDA}.html
   if [[ "$CUDA" != "cpu" ]]; then
     python3 -m pip install dgl-$CUDA
   else


### PR DESCRIPTION
This makes the install script work for the latest version of pip.
Also, it includes two small minor improvments:

* use `python3 -m pip` instead of `pip`
* do not add the ubuntu repository again if has already been added