### PR TITLE
Implement extraction of tokens for AST graphs

### DIFF
--- a/compy/representations/ast_graphs.py
+++ b/compy/representations/ast_graphs.py
@@ -1,5 +1,6 @@
 import networkx as nx
 
+from compy.representations.extractors import clang_driver_scoped_options
 from compy.representations.extractors.extractors import Visitor
 from compy.representations.extractors.extractors import ClangDriver
 from compy.representations.extractors.extractors import ClangExtractor
@@ -118,18 +119,9 @@ class ASTGraphBuilder(common.RepresentationBuilder):
 
         self.__graphs = []
 
-    def string_to_info(self, src, additional_include_dir=None):
-        if additional_include_dir:
-            self.__clang_driver.addIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-        info = self.__extractor.GraphFromString(src)
-        if additional_include_dir:
-            self.__clang_driver.removeIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-
-        return info
+    def string_to_info(self, src, additional_include_dir=None, filename=None):
+        with clang_driver_scoped_options(self.__clang_driver, additional_include_dir=additional_include_dir, filename=filename):
+            return self.__extractor.GraphFromString(src)
 
     def info_to_representation(self, info, visitor=ASTDataVisitor):
         vis = visitor()

--- a/compy/representations/ast_graphs.py
+++ b/compy/representations/ast_graphs.py
@@ -21,6 +21,55 @@ def filter_type(type):
         return "type"
 
 
+def add_ast_edges(g: nx.MultiDiGraph, node):
+    """Add edges with attr `ast` that represent the AST parent-child relationship"""
+
+    if isinstance(node, clang.graph.FunctionInfo):
+        g.add_node(node, attr="function")
+        for arg in node.args:
+            g.add_node(arg, attr=("argument", filter_type(arg.type)))
+            g.add_edge(node, arg, attr="ast")
+
+        g.add_node(node.entryStmt, attr=(node.entryStmt.name))
+        g.add_edge(node, node.entryStmt, attr="ast")
+
+    if isinstance(node, clang.graph.StmtInfo):
+        for ast_rel in node.ast_relations:
+            g.add_node(ast_rel, attr=(ast_rel.name))
+            g.add_edge(node, ast_rel, attr="ast")
+
+
+def add_ref_edges(g: nx.MultiDiGraph, node):
+    """Add edges with attr `data` for data references of the given node"""
+
+    if isinstance(node, clang.graph.StmtInfo):
+        for ref_rel in node.ref_relations:
+            g.add_node(ref_rel, attr=(filter_type(ref_rel.type)))
+            g.add_edge(node, ref_rel, attr="data")
+
+
+def add_cfg_edges(g: nx.MultiDiGraph, node):
+    """Add edges with attr `cfg` or `in` for control flow for the given node"""
+
+    if isinstance(node, clang.graph.FunctionInfo):
+        for cfg_b in node.cfgBlocks:
+            g.add_node(cfg_b, attr="cfg")
+            for succ in cfg_b.successors:
+                g.add_edge(cfg_b, succ, attr="cfg")
+                g.add_node(succ, attr="cfg")
+            for stmt in cfg_b.statements:
+                g.add_edge(stmt, cfg_b, attr="in")
+                g.add_node(stmt, attr=(stmt.name))
+
+
+def add_token_ast_edges(g: nx.MultiDiGraph, node):
+    """Add edges with attr `token` connecting tokens to the closest AST node covering them"""
+    if hasattr(node, 'tokens'):
+        for token in node.tokens:
+            g.add_node(token, attr=token.name)
+            g.add_edge(token, node, attr="token")
+
+
 class ASTVisitor(Visitor):
     def __init__(self):
         Visitor.__init__(self)
@@ -28,19 +77,7 @@ class ASTVisitor(Visitor):
         self.G = nx.MultiDiGraph()
 
     def visit(self, v):
-        if isinstance(v, clang.graph.FunctionInfo):
-            self.G.add_node(v, attr="function")
-            for arg in v.args:
-                self.G.add_node(arg, attr=("argument", filter_type(arg.type)))
-                self.G.add_edge(v, arg, attr="ast")
-
-            self.G.add_node(v.entryStmt, attr=(v.entryStmt.name))
-            self.G.add_edge(v, v.entryStmt, attr="ast")
-
-        if isinstance(v, clang.graph.StmtInfo):
-            for ast_rel in v.ast_relations:
-                self.G.add_node(ast_rel, attr=(ast_rel.name))
-                self.G.add_edge(v, ast_rel, attr="ast")
+        add_ast_edges(self.G, v)
 
 
 class ASTDataVisitor(Visitor):
@@ -50,22 +87,8 @@ class ASTDataVisitor(Visitor):
         self.G = nx.MultiDiGraph()
 
     def visit(self, v):
-        if isinstance(v, clang.graph.FunctionInfo):
-            self.G.add_node(v, attr="function")
-            for arg in v.args:
-                self.G.add_node(arg, attr=("argument", filter_type(arg.type)))
-                self.G.add_edge(v, arg, attr="ast")
-
-            self.G.add_node(v.entryStmt, attr=(v.entryStmt.name))
-            self.G.add_edge(v, v.entryStmt, attr="ast")
-
-        if isinstance(v, clang.graph.StmtInfo):
-            for ast_rel in v.ast_relations:
-                self.G.add_node(ast_rel, attr=(ast_rel.name))
-                self.G.add_edge(v, ast_rel, attr="ast")
-            for ref_rel in v.ref_relations:
-                self.G.add_node(ref_rel, attr=(filter_type(ref_rel.type)))
-                self.G.add_edge(v, ref_rel, attr="data")
+        add_ast_edges(self.G, v)
+        add_ref_edges(self.G, v)
 
 
 class ASTDataCFGVisitor(Visitor):
@@ -75,31 +98,9 @@ class ASTDataCFGVisitor(Visitor):
         self.G = nx.MultiDiGraph()
 
     def visit(self, v):
-        if isinstance(v, clang.graph.FunctionInfo):
-            self.G.add_node(v, attr="function")
-            for arg in v.args:
-                self.G.add_node(arg, attr=("argument", filter_type(arg.type)))
-                self.G.add_edge(v, arg, attr="ast")
-
-            self.G.add_node(v.entryStmt, attr=(v.entryStmt.name))
-            self.G.add_edge(v, v.entryStmt, attr="ast")
-
-            for cfg_b in v.cfgBlocks:
-                self.G.add_node(cfg_b, attr="cfg")
-                for succ in cfg_b.successors:
-                    self.G.add_edge(cfg_b, succ, attr="cfg")
-                    self.G.add_node(succ, attr="cfg")
-                for stmt in cfg_b.statements:
-                    self.G.add_edge(stmt, cfg_b, attr="in")
-                    self.G.add_node(stmt, attr=(stmt.name))
-
-        if isinstance(v, clang.graph.StmtInfo):
-            for ast_rel in v.ast_relations:
-                self.G.add_node(ast_rel, attr=(ast_rel.name))
-                self.G.add_edge(v, ast_rel, attr="ast")
-            for ref_rel in v.ref_relations:
-                self.G.add_node(ref_rel, attr=(filter_type(ref_rel.type)))
-                self.G.add_edge(v, ref_rel, attr="data")
+        add_ast_edges(self.G, v)
+        add_ref_edges(self.G, v)
+        add_cfg_edges(self.G, v)
 
 
 class ASTGraphBuilder(common.RepresentationBuilder):

--- a/compy/representations/ast_graphs.py
+++ b/compy/representations/ast_graphs.py
@@ -66,7 +66,7 @@ def add_token_ast_edges(g: nx.MultiDiGraph, node):
     """Add edges with attr `token` connecting tokens to the closest AST node covering them"""
     if hasattr(node, 'tokens'):
         for token in node.tokens:
-            g.add_node(token, attr=token.name)
+            g.add_node(token, attr=token.name, seq_order=token.index)
             g.add_edge(token, node, attr="token")
 
 
@@ -101,6 +101,19 @@ class ASTDataCFGVisitor(Visitor):
         add_ast_edges(self.G, v)
         add_ref_edges(self.G, v)
         add_cfg_edges(self.G, v)
+
+
+class ASTDataCFGTokenVisitor(Visitor):
+    def __init__(self):
+        Visitor.__init__(self)
+        self.edge_types = ["ast", "cfg", "in", "data", "token"]
+        self.G = nx.MultiDiGraph()
+
+    def visit(self, v):
+        add_ast_edges(self.G, v)
+        add_ref_edges(self.G, v)
+        add_cfg_edges(self.G, v)
+        add_token_ast_edges(self.G, v)
 
 
 class ASTGraphBuilder(common.RepresentationBuilder):

--- a/compy/representations/ast_graphs.py
+++ b/compy/representations/ast_graphs.py
@@ -67,7 +67,7 @@ def add_token_ast_edges(g: nx.MultiDiGraph, node):
     if hasattr(node, 'tokens'):
         for token in node.tokens:
             g.add_node(token, attr=token.name, seq_order=token.index)
-            g.add_edge(token, node, attr="token")
+            g.add_edge(node, token, attr="token")
 
 
 class ASTVisitor(Visitor):

--- a/compy/representations/ast_graphs_test.py
+++ b/compy/representations/ast_graphs_test.py
@@ -1,6 +1,7 @@
 import os
 
 import networkx as nx
+import pytest
 
 from compy.representations.extractors.extractors import Visitor
 from compy.representations.extractors.extractors import clang
@@ -8,6 +9,7 @@ from compy.representations.ast_graphs import ASTGraphBuilder
 from compy.representations.ast_graphs import ASTVisitor
 from compy.representations.ast_graphs import ASTDataVisitor
 from compy.representations.ast_graphs import ASTDataCFGVisitor
+from compy.representations.ast_graphs import ASTDataCFGTokenVisitor
 
 
 program_1fn_2 = """
@@ -48,7 +50,7 @@ def test_construct_with_custom_visitor():
     info = builder.string_to_info(program_1fn_2)
     ast = builder.info_to_representation(info, CustomVisitor)
 
-    assert len(ast.G) == 14
+    assert len(ast.G) == 35
 
 
 # Attributes
@@ -97,3 +99,24 @@ def test_all_visitors():
         ast = builder.info_to_representation(info, visitor)
 
         assert ast
+
+
+def test_token_visitor():
+    builder = ASTGraphBuilder()
+    info = builder.string_to_info(program_1fn_2)
+    ast = builder.info_to_representation(info, ASTDataCFGTokenVisitor)
+
+    assert ast
+    token_data = sorted([data for t, data in ast.G.nodes(data=True) if 'seq_order' in data], key=lambda x: x['seq_order'])
+    tokens = [t['attr'] for t in token_data]
+    assert tokens == [
+        'int', 'bar', '(', 'int', 'a', ')',
+        '{',
+        'if', '(', 'a', '>', '10', ')', 'return', 'a', ';',
+        'return', '-', '1', ';',
+        '}'
+    ]
+
+    leaves = ast.get_leaf_node_list()
+    labels = ast.get_node_str_list()
+    assert [labels[n] for n in leaves] == tokens

--- a/compy/representations/common.py
+++ b/compy/representations/common.py
@@ -120,6 +120,17 @@ class Graph(object):
 
         return edges
 
+    def get_leaf_node_list(self):
+        """Return an ordered list of node indices for leaves of the graph.
+
+        Only applicable for graphs that are built based on a sequence (like ASTs on tokens
+        """
+        nodes_keys = list(self._get_node_attr_dict().keys())
+
+        data = { n: order for n, order in self.G.nodes(data='seq_order') if order is not None }
+        return [nodes_keys.index(n) for n, _ in sorted(data.items(), key=lambda x: x[1])]
+
+
     def size(self):
         return len(self.G)
 

--- a/compy/representations/common.py
+++ b/compy/representations/common.py
@@ -134,7 +134,7 @@ class Graph(object):
     def size(self):
         return len(self.G)
 
-    def draw(self, path=None, with_legend=False):
+    def draw(self, path=None, with_legend=False, align_tokens=True):
         # Copy graph object because attr modifications for a cleaner view are needed.
         G = self.G
 
@@ -184,6 +184,14 @@ class Graph(object):
             for edge_type, color in edge_colors_by_types.items():
                 if edge_type in edge_types_used:
                     subgraph.add_node(edge_type, color="invis", fontcolor=color)
+
+        # Put all tokens on single level ("rank") and enforce order
+        if align_tokens:
+            tokens = graphviz_graph.subgraph(rank="sink", rankdir="LR")
+            leaves = { n: data for n, data in self.G.nodes(data=True) if 'seq_order' in data }
+            leaf_nodes = list(sorted(leaves.items(), key=lambda x: x[1]['seq_order']))
+            for a, b in zip(leaf_nodes, leaf_nodes[1:]) :
+                tokens.add_edge(a[0], b[0], color="invis")
 
         graphviz_graph.layout("dot")
         return graphviz_graph.draw(path)

--- a/compy/representations/common.py
+++ b/compy/representations/common.py
@@ -156,7 +156,10 @@ class Graph(object):
             "mem": "pink",
             "call": "yellow",
         }
-        edge_colors_available = ["orange", "pink"]
+        edge_colors_available = ["orange", "pink", "cyan", "crimson", "darkgreen", "darkblue", "darkcyan"]
+        for etype in self.__edge_types:
+            if etype in edge_colors_by_types: continue
+            edge_colors_by_types[etype] = edge_colors_available.pop(0)
 
         for u, v, key, data in G.edges(keys=True, data=True):
             edge_type = data["attr"]

--- a/compy/representations/common.py
+++ b/compy/representations/common.py
@@ -123,13 +123,76 @@ class Graph(object):
     def get_leaf_node_list(self):
         """Return an ordered list of node indices for leaves of the graph.
 
-        Only applicable for graphs that are built based on a sequence (like ASTs on tokens
+        Only useful for graphs that are built based on a sequence (like ASTs on tokens)
         """
         nodes_keys = list(self._get_node_attr_dict().keys())
 
         data = { n: order for n, order in self.G.nodes(data='seq_order') if order is not None }
         return [nodes_keys.index(n) for n, _ in sorted(data.items(), key=lambda x: x[1])]
 
+    def map_to_leaves(self, relations=None):
+        """Map inner nodes of the graph to leaf nodes.
+
+        Leaves are all nodes which have a `seq_order` attribute.
+        Each node in the graph which is not a leaf is mapped to the descendant leaf with lowest seq_order.
+        All edges are moved to the mapped leaf nodes.
+        Nodes which have no leaf descendants are not transformed.
+
+        The `relations` parameter specifies which edges indicate a parent-child relationship.
+        The value of this parameter must be a dict with two keys, `child` and `parent`.
+        For both keys, the value must be a collection of edge types of that kind.
+
+        Returns the new graph.
+        """
+        if relations is None:
+            relations = {
+                'child': {'ast', 'token'},
+                'parent': {'in', 'data'},
+            }
+        relations.setdefault('parent', set())
+        relations.setdefault('child', set())
+
+        result = nx.MultiDiGraph()
+
+        # Map nodes to leaf node
+        leaf_for_node = {}
+
+        # Walk leaves in sequential order, so sequentially first leaves get priority
+        leaves = { n: data for n, data in self.G.nodes(data=True) if 'seq_order' in data }
+        for leaf, data in sorted(leaves.items(), key=lambda x: x[1]['seq_order']):
+            result.add_node(leaf, **data)
+            # Walk the tree upwards, and assign any unassigned nodes to this leaf
+            todo = { leaf }
+            while todo:
+                n = todo.pop()
+                if n in leaf_for_node and leaf_for_node[n][1] <= data['seq_order']:
+                    # this node has already been assigned to an earlier leaf, so no need to traverse further
+                    continue
+                leaf_for_node[n] = (leaf, data['seq_order'])
+                todo.update(set(target for _, target, attr in self.G.out_edges(n, data='attr') if attr in relations['parent']))
+                todo.update(set(source for source, _, attr in self.G.in_edges(n, data='attr') if attr in relations['child']))
+            # ensure leaves are never mapped to other leaves
+            # this makes sure that the function is idempotent
+            leaf_for_node[leaf] = (leaf, data['seq_order'])
+
+        # Translate edges
+        for source, target, data in self.G.edges(data=True):
+            source = leaf_for_node.get(source, (source, 0))[0]
+            target = leaf_for_node.get(target, (target, 0))[0]
+
+            if source in leaf_for_node:
+                source = leaf_for_node[source][0]
+            else:
+                result.add_node(source, **self.G.nodes(data=True)[source])
+
+            if target in leaf_for_node:
+                target = leaf_for_node[target][0]
+            else:
+                result.add_node(target, **self.G.nodes(data=True)[target])
+
+            result.add_edge(source, target, **data)
+
+        return Graph(result, list(self.__node_types), list(self.__edge_types))
 
     def size(self):
         return len(self.G)

--- a/compy/representations/common_test.py
+++ b/compy/representations/common_test.py
@@ -1,0 +1,80 @@
+import networkx as nx
+
+import compy.representations.common as common
+
+
+def sample_graph():
+    G = nx.MultiDiGraph()
+    G.add_node("root1", attr="root")
+    for n in ["n1", "n2", "n3", "n4", "n5"]:
+        G.add_node(n, attr=n)
+    for n in ["n1", "n2", "n3"]:
+        G.add_edge("root1", n, attr="child")
+    G.add_edge("n4", "n3", attr="parent")
+    G.add_edge("n4", "n5", attr="child")
+    for l in range(7):
+        G.add_node("l" + str(l+1), attr="leaf" + str(l+1), seq_order=l)
+    G.add_edge("n1", "l1", attr="token")
+    G.add_edge("n1", "l2", attr="token")
+    G.add_edge("n2", "l3", attr="token")
+    G.add_edge("root1", "l4", attr="token")
+    G.add_edge("n4", "l5", attr="token")
+    G.add_edge("n4", "l6", attr="token")
+    G.add_edge("n4", "l7", attr="token")
+    G.add_edge("root1", "n3", attr="rel2")
+    G.add_edge("l1", "l2", attr="token_rel")
+    G.add_edge("n2", "l2", attr="node_token_rel")
+    return common.Graph(G,
+                        list(sorted(set(attr for _, attr in G.nodes(data="attr")))),
+                        list(sorted(set(attr for _, _, attr in G.edges(data="attr")))))
+
+
+def test_map_to_leaves():
+    graph = sample_graph()
+    relations = {'child': {'token', 'child'}, 'parent': {'parent'}}
+    leaves_only = graph.map_to_leaves(relations)
+
+    # n5 is kept because it has no child nodes
+    assert sorted(leaves_only.get_node_str_list()) == ['leaf1', 'leaf2', 'leaf3', 'leaf4', 'leaf5', 'leaf6', 'leaf7', 'n5']
+
+    # map to leaves should be idempotent
+    assert sorted(graph.map_to_leaves(relations).G.edges(data='attr')) == sorted(
+        leaves_only.map_to_leaves(relations).G.edges(data='attr'))
+
+    edges = sorted(leaves_only.G.edges(data='attr'))
+    expected_edges = [
+        ('l1', 'l1', 'token'),
+        ('l1', 'l2', 'token'),
+        ('l3', 'l3', 'token'),
+        ('l1', 'l4', 'token'),
+        ('l5', 'l5', 'token'),
+        ('l5', 'l6', 'token'),
+        ('l5', 'l7', 'token'),
+        ('l1', 'l1', 'child'),
+        ('l1', 'l3', 'child'),
+        ('l1', 'l5', 'child'),
+        ('l5', 'n5', 'child'),
+        ('l1', 'l2', 'token_rel'),
+        ('l3', 'l2', 'node_token_rel'),
+        ('l1', 'l5', 'rel2'),
+        ('l5', 'l5', 'parent'),
+    ]
+    assert edges == sorted(expected_edges)
+
+    without_parent = graph.map_to_leaves({'child': ['token', 'child']})
+    assert sorted(without_parent.get_node_str_list()) == ['leaf1', 'leaf2', 'leaf3', 'leaf4', 'leaf5', 'leaf6', 'leaf7', 'n3', 'n5']
+
+def test_map_to_leaves_cycle():
+    cycle = nx.MultiDiGraph()
+    for node in ["0", "1", "2", "4"]:
+        cycle.add_node(node, attr=node)
+    cycle.add_edge("0", "1", attr='flow')
+    cycle.add_edge("1", "2", attr='flow')
+    cycle.add_edge("2", "0", attr='flow')
+    cycle.add_edge("4", "0", attr='flow')
+    cycle.add_node('leaf', attr='leaf', seq_order=0)
+    cycle.add_edge("0", 'leaf', attr='flow')
+
+    graph = common.Graph(cycle, [], ['leaf', "0", "1", "2", "4"])
+    mapped = graph.map_to_leaves({'child': 'flow'})
+    assert sorted(mapped.G.edges(data=False)) == [("leaf", "leaf")] * 5

--- a/compy/representations/extractors/__init__.py
+++ b/compy/representations/extractors/__init__.py
@@ -1,1 +1,34 @@
+from typing import Optional
+import contextlib
+
 from .extractors import ClangDriver
+
+@contextlib.contextmanager
+def clang_driver_scoped_options(clang_driver, additional_include_dir: Optional[str] = None, filename: Optional[str] = None):
+    """A context manager to set and restore options for the clang driver in a local scope.
+
+    >>> with clang_driver_scoped_options(clang_driver, filename="foo"):
+    ...     # clang_driver's file name is set to foo in this scope
+    ...     pass
+    ... # filename is restored to previous value after the with block
+    """
+    prev_filename = None
+    if filename is not None:
+        prev_filename = clang_driver.getFileName()
+        clang_driver.setFileName(filename)
+    
+    if additional_include_dir:
+        clang_driver.addIncludeDir(
+            additional_include_dir, ClangDriver.IncludeDirType.User
+        )
+    
+    try:
+        yield clang_driver
+    finally:
+        if prev_filename is not None:
+            clang_driver.setFileName(prev_filename)
+        if additional_include_dir:
+            clang_driver.removeIncludeDir(
+                additional_include_dir, ClangDriver.IncludeDirType.User
+            )
+               

--- a/compy/representations/extractors/__init__.py
+++ b/compy/representations/extractors/__init__.py
@@ -7,6 +7,7 @@ import warnings
 from typing import Optional
 
 from .extractors import ClangDriver, LLVM_VERSION
+del extractors # HACK: don't override extractors
 
 
 @functools.lru_cache()

--- a/compy/representations/extractors/__init__.py
+++ b/compy/representations/extractors/__init__.py
@@ -1,7 +1,58 @@
-from typing import Optional
 import contextlib
+import functools
+import itertools
+import shutil
+import subprocess
+import warnings
+from typing import Optional
 
-from .extractors import ClangDriver
+from .extractors import ClangDriver, LLVM_VERSION
+
+
+@functools.lru_cache()
+def clang_binary_path():
+    """Find the clang compiler binary, trying to match the version that the native extension was compiled with.
+
+    Prints a warning if the binary that was found is a different version.
+    Raises RuntimeException if no clang compiler is found at all.
+    """
+    best_score = None
+    best_version = None
+    best_path = None
+
+    components = LLVM_VERSION.split('.')
+    for suffix_len in reversed(range(len(components) + 1)):
+        suffix = '.'.join(components[:suffix_len])
+        path = shutil.which(f"clang-{suffix}" if suffix else "clang")
+        if path is None:
+            continue
+
+        llvm_config_path = subprocess.run(
+            [path, "-print-prog-name=llvm-config"],
+            check=True, stdout=subprocess.PIPE
+        ).stdout.decode().strip()
+
+        this_version = subprocess.run(
+            [llvm_config_path, "--version"],
+            check=True, stdout=subprocess.PIPE
+        ).stdout.decode().strip()
+
+        if this_version == LLVM_VERSION:
+            return path
+
+        score = sum(1 for _ in itertools.takewhile(lambda x: x[0] == x[1], zip(this_version, LLVM_VERSION)))
+        if best_score is None or score > best_score:
+            best_score = score
+            best_version = this_version
+            best_path = path
+
+    if not best_path:
+        raise RuntimeError("cannot find clang compiler binary in PATH")
+
+    warnings.warn(f"found clang compiler at {best_path} for LLVM {best_version}, but native extension was compiled "
+                  f"against LLVM {LLVM_VERSION}")
+    return best_path
+
 
 @contextlib.contextmanager
 def clang_driver_scoped_options(clang_driver, additional_include_dir: Optional[str] = None, filename: Optional[str] = None):
@@ -16,12 +67,12 @@ def clang_driver_scoped_options(clang_driver, additional_include_dir: Optional[s
     if filename is not None:
         prev_filename = clang_driver.getFileName()
         clang_driver.setFileName(filename)
-    
+
     if additional_include_dir:
         clang_driver.addIncludeDir(
             additional_include_dir, ClangDriver.IncludeDirType.User
         )
-    
+
     try:
         yield clang_driver
     finally:
@@ -31,4 +82,4 @@ def clang_driver_scoped_options(clang_driver, additional_include_dir: Optional[s
             clang_driver.removeIncludeDir(
                 additional_include_dir, ClangDriver.IncludeDirType.User
             )
-               
+

--- a/compy/representations/extractors/clang_ast/clang_extractor.cc
+++ b/compy/representations/extractors/clang_ast/clang_extractor.cc
@@ -21,13 +21,12 @@ ClangExtractor::ClangExtractor(ClangDriverPtr clangDriver)
     : clangDriver_(clangDriver) {}
 
 graph::ExtractionInfoPtr ClangExtractor::GraphFromString(std::string src) {
-  compy::clang::graph::ExtractorFrontendAction *fa =
-      new compy::clang::graph::ExtractorFrontendAction();
+  auto fa = std::make_unique<compy::clang::graph::ExtractorFrontendAction>();
 
   std::vector<::clang::FrontendAction *> frontendActions;
   std::vector<::llvm::Pass *> passes;
 
-  frontendActions.push_back(fa);
+  frontendActions.push_back(fa.get());
 
   clangDriver_->Invoke(src, frontendActions, passes);
 
@@ -35,13 +34,12 @@ graph::ExtractionInfoPtr ClangExtractor::GraphFromString(std::string src) {
 }
 
 seq::ExtractionInfoPtr ClangExtractor::SeqFromString(std::string src) {
-  compy::clang::seq::ExtractorFrontendAction *fa =
-      new compy::clang::seq::ExtractorFrontendAction();
+  auto fa = std::make_unique<compy::clang::seq::ExtractorFrontendAction>();
 
   std::vector<::clang::FrontendAction *> frontendActions;
   std::vector<::llvm::Pass *> passes;
 
-  frontendActions.push_back(fa);
+  frontendActions.push_back(fa.get());
 
   clangDriver_->Invoke(src, frontendActions, passes);
 

--- a/compy/representations/extractors/clang_ast/clang_extractor.h
+++ b/compy/representations/extractors/clang_ast/clang_extractor.h
@@ -83,7 +83,9 @@ struct OperandInfo : IVisitee {
 struct DeclInfo : OperandInfo {
   std::string name;
   std::string type;
+  std::string kind;
   std::vector<TokenInfo> tokens;
+  TokenInfo nameToken;
 
   void accept(IVisitor* v) override {
     v->visit(this);

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.cc
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.cc
@@ -33,7 +33,8 @@ bool ExtractorASTVisitor::VisitStmt(Stmt *s) {
   }
 
   StmtInfoPtr info = getInfo(*s);
-  info->ast_relations = std::move(ast_relations);
+  info->ast_relations.insert(info->ast_relations.end(), ast_relations.begin(),
+                             ast_relations.end());
 
   return RecursiveASTVisitor<ExtractorASTVisitor>::VisitStmt(s);
 }

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.cc
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.cc
@@ -30,6 +30,12 @@ bool ExtractorASTVisitor::VisitStmt(Stmt *s) {
     }
   }
 
+  if (auto *ds = dyn_cast<DeclStmt>(s)) {
+    for (const Decl *decl : ds->decls()) {
+      ast_relations.push_back(getInfo(*decl, false));
+    }
+  }
+
   StmtInfoPtr info = getInfo(*s);
   info->ast_relations.insert(info->ast_relations.end(), ast_relations.begin(),
                              ast_relations.end());

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.cc
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.cc
@@ -147,7 +147,15 @@ StmtInfoPtr ExtractorASTVisitor::getInfo(const Stmt &stmt) {
 
 DeclInfoPtr ExtractorASTVisitor::getInfo(const Decl &decl, bool consumeTokens) {
   auto it = declInfos_.find(&decl);
-  if (it != declInfos_.end()) return it->second;
+  if (it != declInfos_.end()) {
+    if (consumeTokens) {
+      auto tokens = tokenQueue_.popTokensForRange(decl.getSourceRange());
+      it->second->tokens.insert(it->second->tokens.end(), tokens.begin(),
+                                tokens.end());
+    }
+
+    return it->second;
+  }
 
   DeclInfoPtr info(new DeclInfo);
   declInfos_[&decl] = info;

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
@@ -61,7 +61,7 @@ class ExtractorASTVisitor
   FunctionInfoPtr getInfo(const ::clang::FunctionDecl &func);
   CFGBlockInfoPtr getInfo(const ::clang::CFGBlock &block);
   StmtInfoPtr getInfo(const ::clang::Stmt &stmt);
-  DeclInfoPtr getInfo(const ::clang::Decl &decl);
+  DeclInfoPtr getInfo(const ::clang::Decl &decl, bool consumeTokens);
 
  private:
   ::clang::ASTContext &context_;

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
@@ -39,6 +39,9 @@ class TokenQueue {
 
   ::clang::Preprocessor &pp_;
   std::vector<TokenInfo> tokens_;
+  std::vector<bool> token_consumed_;
+  llvm::DenseMap<unsigned, std::size_t> token_index_;
+
   std::uint64_t nextIndex = 0;
 };
 

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
@@ -17,15 +17,45 @@ namespace compy {
 namespace clang {
 namespace graph {
 
+/**
+ * Keeps a queue of tokens that are not assigned to any AST-Graph node yet
+ */
+class TokenQueue {
+ public:
+  TokenQueue(::clang::Preprocessor &pp) : pp_(pp) {
+    pp_.setTokenWatcher([this](auto token) { this->addToken(token); });
+  }
+
+  TokenQueue(TokenQueue const &) = delete;
+  TokenQueue &operator=(TokenQueue const &) = delete;
+
+  ~TokenQueue() { pp_.setTokenWatcher(nullptr); }
+
+  std::vector<TokenInfo> popTokensForRange(::clang::SourceRange range);
+
+ private:
+  void addToken(::clang::Token token);
+
+  ::clang::Preprocessor &pp_;
+  std::vector<TokenInfo> tokens_;
+  std::uint64_t nextIndex = 0;
+};
+
 class ExtractorASTVisitor
     : public ::clang::RecursiveASTVisitor<ExtractorASTVisitor> {
  public:
   ExtractorASTVisitor(::clang::ASTContext &context,
-                      ExtractionInfoPtr extractionInfo)
-      : context_(context), extractionInfo_(extractionInfo) {}
+                      ExtractionInfoPtr extractionInfo, TokenQueue &tokenQueue)
+      : context_(context),
+        extractionInfo_(extractionInfo),
+        tokenQueue_(tokenQueue) {}
 
   bool VisitStmt(::clang::Stmt *s);
   bool VisitFunctionDecl(::clang::FunctionDecl *f);
+
+  // postorder traversal is necessary so that tokens get assigned to
+  // nodes closer to the leaves first
+  bool shouldTraversePostOrder() const { return true; }
 
  private:
   FunctionInfoPtr getInfo(const ::clang::FunctionDecl &func);
@@ -36,6 +66,7 @@ class ExtractorASTVisitor
  private:
   ::clang::ASTContext &context_;
   ExtractionInfoPtr extractionInfo_;
+  TokenQueue &tokenQueue_;
 
   std::unordered_map<const ::clang::Stmt *, StmtInfoPtr> stmtInfos_;
   std::unordered_map<const ::clang::CFGBlock *, CFGBlockInfoPtr> cfgBlockInfos_;
@@ -44,13 +75,14 @@ class ExtractorASTVisitor
 
 class ExtractorASTConsumer : public ::clang::ASTConsumer {
  public:
-  ExtractorASTConsumer(::clang::ASTContext &context,
+  ExtractorASTConsumer(::clang::CompilerInstance &CI,
                        ExtractionInfoPtr extractionInfo);
 
   bool HandleTopLevelDecl(::clang::DeclGroupRef DR) override;
 
  private:
   ExtractorASTVisitor visitor_;
+  TokenQueue tokenQueue_;
 };
 
 class ExtractorFrontendAction : public ::clang::ASTFrontendAction {

--- a/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
+++ b/compy/representations/extractors/clang_ast/clang_graph_frontendaction.h
@@ -32,6 +32,7 @@ class TokenQueue {
   ~TokenQueue() { pp_.setTokenWatcher(nullptr); }
 
   std::vector<TokenInfo> popTokensForRange(::clang::SourceRange range);
+  TokenInfo *getTokenAt(::clang::SourceLocation loc);
 
  private:
   void addToken(::clang::Token token);

--- a/compy/representations/extractors/common/clang_driver.cc
+++ b/compy/representations/extractors/common/clang_driver.cc
@@ -164,6 +164,10 @@ void ClangDriver::Invoke(std::string src,
       std::cout << "# " << I->second << '\n';
     throw std::runtime_error("Failed parsing compilation arguments");
   }
+
+  // We should not leak memory
+  invocation->getFrontendOpts().DisableFree = 0;
+
   Clang->setInvocation(invocation);
 
   // Map code filename to a memoryBuffer.

--- a/compy/representations/extractors/common/clang_driver.cc
+++ b/compy/representations/extractors/common/clang_driver.cc
@@ -53,10 +53,21 @@ ClangDriver::ClangDriver(
     OptimizationLevel optimizationLevel,
     std::vector<std::tuple<std::string, IncludeDirType>> includeDirs,
     std::vector<std::string> compilerFlags)
-    : programmingLanguage_(programmingLanguage),
-      optimizationLevel_(optimizationLevel),
+    : optimizationLevel_(optimizationLevel),
       includeDirs_(includeDirs),
-      compilerFlags_(compilerFlags) {}
+      compilerFlags_(compilerFlags) {
+  switch (programmingLanguage) {
+    case ProgrammingLanguage::C:
+      fileName_ = "program.c";
+      break;
+    case ProgrammingLanguage::CPLUSPLUS:
+      fileName_ = "program.cc";
+      break;
+    case ProgrammingLanguage::OPENCL:
+      fileName_ = "program.cl";
+      break;
+  }
+}
 
 void ClangDriver::addIncludeDir(std::string includeDir,
                                 IncludeDirType includeDirType) {
@@ -75,21 +86,17 @@ void ClangDriver::setOptimizationLevel(OptimizationLevel optimizationLevel) {
   optimizationLevel_ = optimizationLevel;
 }
 
+void ClangDriver::setFileName(std::string fileName) {
+  fileName_ = std::move(fileName);
+}
+
+std::string ClangDriver::getFileName() const { return fileName_; }
+
 void ClangDriver::Invoke(std::string src,
                          std::vector<::clang::FrontendAction *> frontendActions,
                          std::vector<::llvm::Pass *> passes) {
-  const char *filename;
-  switch (programmingLanguage_) {
-    case ProgrammingLanguage::C:
-      filename = "program.c";
-      break;
-    case ProgrammingLanguage::CPLUSPLUS:
-      filename = "program.cc";
-      break;
-    case ProgrammingLanguage::OPENCL:
-      filename = "program.cl";
-      break;
-  }
+  const char *filename = fileName_.c_str();
+
   auto code = src.c_str();
 
   std::vector<const char *> args;
@@ -183,7 +190,6 @@ void ClangDriver::Invoke(std::string src,
                                                 E = DiagsBuffer->err_end();
            I != E; ++I)
         std::cout << "# " << I->second << '\n';
-
       throw std::runtime_error("Failed compiling to execute frontend action");
     }
   }

--- a/compy/representations/extractors/common/clang_driver.h
+++ b/compy/representations/extractors/common/clang_driver.h
@@ -38,6 +38,8 @@ class ClangDriver {
   void setOptimizationLevel(OptimizationLevel optimizationLevel);
   void setFileName(std::string fileName);
   std::string getFileName() const;
+  void setCompilerBinary(std::string path);
+  std::string getCompilerBinary() const;
 
   void Invoke(std::string src,
               std::vector<::clang::FrontendAction *> frontendActions,
@@ -50,6 +52,7 @@ class ClangDriver {
   std::vector<std::tuple<std::string, IncludeDirType>> includeDirs_;
   std::vector<std::string> compilerFlags_;
   std::string fileName_;
+  std::string compilerBinary_;
 };
 using ClangDriverPtr = std::shared_ptr<ClangDriver>;
 

--- a/compy/representations/extractors/common/clang_driver.h
+++ b/compy/representations/extractors/common/clang_driver.h
@@ -36,6 +36,8 @@ class ClangDriver {
   void addIncludeDir(std::string includeDir, IncludeDirType includeDirType);
   void removeIncludeDir(std::string includeDir, IncludeDirType includeDirType);
   void setOptimizationLevel(OptimizationLevel optimizationLevel);
+  void setFileName(std::string fileName);
+  std::string getFileName() const;
 
   void Invoke(std::string src,
               std::vector<::clang::FrontendAction *> frontendActions,
@@ -44,10 +46,10 @@ class ClangDriver {
  private:
   std::shared_ptr<::llvm::legacy::PassManager> pm_;
 
-  ProgrammingLanguage programmingLanguage_;
   OptimizationLevel optimizationLevel_;
   std::vector<std::tuple<std::string, IncludeDirType>> includeDirs_;
   std::vector<std::string> compilerFlags_;
+  std::string fileName_;
 };
 using ClangDriverPtr = std::shared_ptr<ClangDriver>;
 

--- a/compy/representations/extractors/extractors.cc
+++ b/compy/representations/extractors/extractors.cc
@@ -83,7 +83,9 @@ void registerClangDriver(py::module m) {
       .def("addIncludeDir", &CD::addIncludeDir)
       .def("removeIncludeDir", &CD::removeIncludeDir)
       .def("getFileName", &CD::getFileName)
-      .def("setFileName", &CD::setFileName);
+      .def("setFileName", &CD::setFileName)
+      .def("getCompilerBinary", &CD::getCompilerBinary)
+      .def("setCompilerBinary", &CD::setCompilerBinary);
 
   py::enum_<CD::ProgrammingLanguage>(clangDriver, "ProgrammingLanguage")
       .value("C", CD::ProgrammingLanguage::C)
@@ -256,6 +258,8 @@ void registerLLVMExtractor(py::module m_parent) {
 }
 
 PYBIND11_MODULE(extractors, m) {
+  m.attr("LLVM_VERSION") = LLVM_VERSION_STRING;
+
   py::class_<IVisitor, PyVisitor>(m, "Visitor").def(py::init<>());
 
   registerClangDriver(m);

--- a/compy/representations/extractors/extractors.cc
+++ b/compy/representations/extractors/extractors.cc
@@ -126,12 +126,14 @@ void registerClangExtractor(py::module m_parent) {
 
   py::class_<cg::DeclInfo, std::shared_ptr<cg::DeclInfo>>(m_graph, "DeclInfo")
       .def_readonly("name", &cg::DeclInfo::name)
+      .def_readonly("tokens", &cg::DeclInfo::tokens)
       .def_readonly("type", &cg::DeclInfo::type);
 
   py::class_<cg::FunctionInfo, std::shared_ptr<cg::FunctionInfo>>(
       m_graph, "FunctionInfo")
       .def("accept", &cg::FunctionInfo::accept)
       .def_readonly("name", &cg::FunctionInfo::name)
+      .def_readonly("tokens", &cg::FunctionInfo::tokens)
       .def_readonly("type", &cg::FunctionInfo::type)
       .def_readonly("args", &cg::FunctionInfo::args)
       .def_readonly("cfgBlocks", &cg::FunctionInfo::cfgBlocks)
@@ -145,8 +147,15 @@ void registerClangExtractor(py::module m_parent) {
 
   py::class_<cg::StmtInfo, std::shared_ptr<cg::StmtInfo>>(m_graph, "StmtInfo")
       .def_readonly("name", &cg::StmtInfo::name)
+      .def_readonly("tokens", &cg::StmtInfo::tokens)
       .def_readonly("ast_relations", &cg::StmtInfo::ast_relations)
       .def_readonly("ref_relations", &cg::StmtInfo::ref_relations);
+
+  py::class_<cg::TokenInfo, std::shared_ptr<cg::TokenInfo>>(m_graph,
+                                                            "TokenInfo")
+      .def_readonly("name", &cg::TokenInfo::name)
+      .def_readonly("kind", &cg::TokenInfo::kind)
+      .def_readonly("index", &cg::TokenInfo::index);
 
   // Sequence extractor
   py::module m_seq = m.def_submodule("seq");

--- a/compy/representations/extractors/extractors.cc
+++ b/compy/representations/extractors/extractors.cc
@@ -81,7 +81,9 @@ void registerClangDriver(py::module m) {
                     std::vector<std::tuple<std::string, CD::IncludeDirType>>,
                     std::vector<std::string>>())
       .def("addIncludeDir", &CD::addIncludeDir)
-      .def("removeIncludeDir", &CD::removeIncludeDir);
+      .def("removeIncludeDir", &CD::removeIncludeDir)
+      .def("getFileName", &CD::getFileName)
+      .def("setFileName", &CD::setFileName);
 
   py::enum_<CD::ProgrammingLanguage>(clangDriver, "ProgrammingLanguage")
       .value("C", CD::ProgrammingLanguage::C)

--- a/compy/representations/extractors/extractors.cc
+++ b/compy/representations/extractors/extractors.cc
@@ -126,6 +126,8 @@ void registerClangExtractor(py::module m_parent) {
 
   py::class_<cg::DeclInfo, std::shared_ptr<cg::DeclInfo>>(m_graph, "DeclInfo")
       .def_readonly("name", &cg::DeclInfo::name)
+      .def_readonly("kind", &cg::DeclInfo::kind)
+      .def_readonly("nameToken", &cg::DeclInfo::nameToken)
       .def_readonly("tokens", &cg::DeclInfo::tokens)
       .def_readonly("type", &cg::DeclInfo::type);
 

--- a/compy/representations/extractors/extractors_test.py
+++ b/compy/representations/extractors/extractors_test.py
@@ -279,7 +279,7 @@ def test_llvm_seq_functions_have_signature_and_names(llvm_extractor_fixture):
     fn = info.functionInfos[0]
 
     assert fn.name == "foo"
-    assert fn.signature == ["define ", "i", "32", " ", "@", "foo", "(", ")", " #", "0"]
+    assert fn.signature == ["define ", "dso_local ", "i", "32", " ", "@", "foo", "(", ")", " #", "0"]
 
 
 # Seq tests: Basicblocks
@@ -319,7 +319,8 @@ def get_statements_with_name(stmt, name):
     for child in stmt.ast_relations:
         if child.name == name:
             ret += [child]
-        ret += get_statements_with_name(child, name)
+        if hasattr(child, 'ast_relations'):
+            ret += get_statements_with_name(child, name)
 
     return ret
 

--- a/compy/representations/extractors/llvm_ir/CMakeLists.txt
+++ b/compy/representations/extractors/llvm_ir/CMakeLists.txt
@@ -27,3 +27,6 @@ target_link_libraries(llvm_extractor_tests
 target_compile_options(llvm_extractor_tests PRIVATE
         -fno-rtti -fPIC
         )
+target_compile_definitions(llvm_extractor_tests PRIVATE
+        CLANG_INSTALL_PREFIX=${CLANG_INSTALL_PREFIX}
+        )

--- a/compy/representations/extractors/llvm_ir/llvm_extractor_test.cc
+++ b/compy/representations/extractors/llvm_ir/llvm_extractor_test.cc
@@ -6,6 +6,9 @@
 #include "common/common_test.h"
 #include "gtest/gtest.h"
 
+#define TO_STRING(prefix) #prefix
+#define COMPILER_BINARY(prefix) TO_STRING(prefix) "/bin/clang"
+
 using namespace ::llvm;
 using namespace compy;
 using namespace compy::llvm;
@@ -26,19 +29,13 @@ class LLVMExtractorFixture : public testing::Test {
  protected:
   void Init(CD::ProgrammingLanguage programmingLanguage) {
     // Init extractor
-    std::vector<std::tuple<std::string, CD::IncludeDirType>> includeDirs = {
-        std::make_tuple("/usr/include", CD::IncludeDirType::SYSTEM),
-        std::make_tuple("/usr/include/x86_64-linux-gnu",
-                        CD::IncludeDirType::SYSTEM),
-        std::make_tuple("/usr/lib/llvm-10/lib/clang/10.0.0/include",
-                        CD::IncludeDirType::SYSTEM),
-        std::make_tuple("/usr/lib/llvm-10/lib/clang/10.0.1/include",
-                        CD::IncludeDirType::SYSTEM)};
+    std::vector<std::tuple<std::string, CD::IncludeDirType>> includeDirs = {};
     std::vector<std::string> compilerFlags = {"-Werror"};
 
     driver_.reset(new ClangDriver(programmingLanguage,
                                   CD::OptimizationLevel::O0, includeDirs,
                                   compilerFlags));
+    driver_->setCompilerBinary(COMPILER_BINARY(CLANG_INSTALL_PREFIX));
     extractor_.reset(new LE(driver_));
   }
 

--- a/compy/representations/extractors/llvm_ir/llvm_graph_funcinfo.cc
+++ b/compy/representations/extractors/llvm_ir/llvm_graph_funcinfo.cc
@@ -26,7 +26,7 @@ std::string llvmTypeToString(Type *type) {
  * based on the default name.
  */
 std::string FunctionInfoPass::getUniqueName(const Value &v) {
-  if (v.hasName()) return v.getName();
+  if (v.hasName()) return v.getName().str();
 
   auto iter = valueNames.find(&v);
   if (iter != valueNames.end()) return iter->second;

--- a/compy/representations/extractors/llvm_ir/llvm_graph_pass.cc
+++ b/compy/representations/extractors/llvm_ir/llvm_graph_pass.cc
@@ -44,7 +44,7 @@ bool ExtractorPass::runOnModule(::llvm::Module &module) {
       // Skip for functions without definition (fwd declarations)
       if (kv.second->getFunction()) {
         info->callGraphInfo->calls.push_back(
-            kv.second->getFunction()->getName());
+            kv.second->getFunction()->getName().str());
       }
     }
   }

--- a/compy/representations/extractors/llvm_ir/llvm_seq_pass.cc
+++ b/compy/representations/extractors/llvm_ir/llvm_seq_pass.cc
@@ -168,7 +168,7 @@ bool ExtractorPass::runOnModule(::llvm::Module &module) {
     F.print(TokenStream, tokenAnnotator.get());
 
     FunctionInfoPtr functionInfo = infoBuilder->getInfo();
-    functionInfo->name = F.getName();
+    functionInfo->name = F.getName().str();
     functionInfo->str = TokenStream.getStr();
     info->functionInfos.push_back(functionInfo);
   }

--- a/compy/representations/llvm_graphs.py
+++ b/compy/representations/llvm_graphs.py
@@ -1,5 +1,6 @@
 import networkx as nx
 
+from compy.representations.extractors import clang_driver_scoped_options
 from compy.representations.extractors.extractors import Visitor
 from compy.representations.extractors.extractors import ClangDriver
 from compy.representations.extractors.extractors import LLVMIRExtractor
@@ -242,18 +243,9 @@ class LLVMGraphBuilder(common.RepresentationBuilder):
             )
         self.__extractor = LLVMIRExtractor(self.__clang_driver)
 
-    def string_to_info(self, src, additional_include_dir=None):
-        if additional_include_dir:
-            self.__clang_driver.addIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-        info = self.__extractor.GraphFromString(src)
-        if additional_include_dir:
-            self.__clang_driver.removeIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-
-        return info
+    def string_to_info(self, src, additional_include_dir=None, filename=None):
+        with clang_driver_scoped_options(self.__clang_driver, additional_include_dir=additional_include_dir, filename=filename):
+            return self.__extractor.GraphFromString(src)
 
     def info_to_representation(self, info, visitor=LLVMCDFGVisitor):
         vis = visitor()

--- a/compy/representations/llvm_seq.py
+++ b/compy/representations/llvm_seq.py
@@ -1,3 +1,4 @@
+from compy.representations.extractors import clang_driver_scoped_options
 from compy.representations.extractors.extractors import Visitor
 from compy.representations.extractors.extractors import ClangDriver
 from compy.representations.extractors.extractors import LLVMIRExtractor
@@ -83,19 +84,10 @@ class LLVMSeqBuilder(common.RepresentationBuilder):
             )
         self.__extractor = LLVMIRExtractor(self.__clang_driver)
 
-    def string_to_info(self, src, additional_include_dir=None):
-        if additional_include_dir:
-            self.__clang_driver.addIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-        info = self.__extractor.SeqFromString(src)
-        if additional_include_dir:
-            self.__clang_driver.removeIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-
-        return info
-
+    def string_to_info(self, src, additional_include_dir=None, filename=None):
+        with clang_driver_scoped_options(self.__clang_driver, additional_include_dir=additional_include_dir, filename=filename):
+            return self.__extractor.SeqFromString(src)
+        
     def info_to_representation(self, info, visitor=LLVMSeqVisitor):
         vis = visitor()
         info.accept(vis)

--- a/compy/representations/syntax_seq.py
+++ b/compy/representations/syntax_seq.py
@@ -1,3 +1,4 @@
+from compy.representations.extractors import clang_driver_scoped_options
 from compy.representations.extractors.extractors import Visitor
 from compy.representations.extractors.extractors import ClangDriver
 from compy.representations.extractors.extractors import ClangExtractor
@@ -60,18 +61,9 @@ class SyntaxSeqBuilder(common.RepresentationBuilder):
             )
         self.__extractor = ClangExtractor(self.__clang_driver)
 
-    def string_to_info(self, src, additional_include_dir=None):
-        if additional_include_dir:
-            self.__clang_driver.addIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-        info = self.__extractor.SeqFromString(src)
-        if additional_include_dir:
-            self.__clang_driver.removeIncludeDir(
-                additional_include_dir, ClangDriver.IncludeDirType.User
-            )
-
-        return info
+    def string_to_info(self, src, additional_include_dir=None, filename=None):
+        with clang_driver_scoped_options(self.__clang_driver, additional_include_dir=additional_include_dir, filename=filename):
+            return self.__extractor.SeqFromString(src)
 
     def info_to_representation(self, info, visitor=SyntaxTokenkindVariableVisitor):
         vis = visitor()

--- a/examples/devmap_exploration.py
+++ b/examples/devmap_exploration.py
@@ -34,7 +34,7 @@ for builder, visitor, model in combinations:
         ClangDriver.ProgrammingLanguage.OpenCL,
         ClangDriver.OptimizationLevel.O3,
         [(x, ClangDriver.IncludeDirType.User) for x in dataset.additional_include_dirs],
-        ["-xcl"],
+        ["-xcl", "-target", "x86_64-pc-linux-gnu"],
     )
     data = dataset.preprocess(builder(clang_driver), visitor)
 


### PR DESCRIPTION
Adds support for obtaining tokens for AST nodes and associating them. There are also two minor clang driver improvements: support for driver flags (like `-target`) and support for setting the file name for each sample (so letting clang determine the correct source language automatically based on the extension).