### PR TITLE
TfGnnModel: packaging fix + support tf 2.5

### DIFF
--- a/compy/models/graphs/tf/layer/gnn_model_layer.py
+++ b/compy/models/graphs/tf/layer/gnn_model_layer.py
@@ -99,6 +99,7 @@ class GGNNModelLayer(PropagationModelLayer):
         edge_targets = tf.concat(edge_targets, axis=0)  # [M]
 
         # Propagate
+        embeddings = [embeddings]
         for step in range(self.config["num_timesteps"]):
             messages = []  # list of tensors of messages of shape [e, h]
             message_source_states = (


### PR DESCRIPTION
This fixes a small package issue (compy.models.graphs.tf.cell was missing an `__init__.py` file) and also contains a small adaption to make the code work on tensorflow 2.5.